### PR TITLE
Fix MSIX config and add macOS PKG packaging

### DIFF
--- a/distribute_options.yaml
+++ b/distribute_options.yaml
@@ -131,15 +131,15 @@ releases:
             repo-owner: arran4
             repo-name: flutter_google_datastore
 # Disabled for packaging reasons atm.
-#      - name: macos-pkg
-#        package:
-#          platform: macos
-#          target: pkg
-#        publish:
-#          target: github
-#          args:
-#            repo-owner: arran4
-#            repo-name: flutter_google_datastore
+      - name: macos-pkg
+        package:
+          platform: macos
+          target: pkg
+        publish:
+          target: github
+          args:
+            repo-owner: arran4
+            repo-name: flutter_google_datastore
       - name: macos-zip
         package:
           platform: macos

--- a/macos/packaging/pkg/make_config.yaml
+++ b/macos/packaging/pkg/make_config.yaml
@@ -1,0 +1,1 @@
+install-path: /Applications/

--- a/windows/packaging/msix/make_config.yaml
+++ b/windows/packaging/msix/make_config.yaml
@@ -1,3 +1,3 @@
 display_name: Flutter Google Datastore
 msix_version: 1.0.0.0
-install_certificate: false
+install_certificate: 'false'


### PR DESCRIPTION
## Summary
- fix msix config by quoting `install_certificate`
- enable macOS pkg target in distribute options
- add example `macos/packaging/pkg/make_config.yaml`

## Testing
- `flutter/bin/flutter --version` *(fails: missing setup)*

------
https://chatgpt.com/codex/tasks/task_e_6843b63bac7c832fb720bbe1a72b3e81