### PR TITLE
Add Flatpak build pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,6 +92,51 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
+  flatpak:
+    runs-on: ubuntu-latest
+    needs: linux
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: '3.7.0'
+      - uses: subosito/flutter-action@v2
+        with:
+          cache: true
+          flutter-version: ${{ env.FLUTTER_SDK_VERSION }}
+      - name: Install Flatpak tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y flatpak flatpak-builder ostree gpg git
+      - name: Set up environment vars
+        run: |
+          TAG_NAME=$(echo ${GITHUB_REF#refs/tags/v})
+          VERSION="$TAG_NAME"
+          echo "SEMANTIC_VERSION=$TAG_NAME" >> $GITHUB_ENV
+          echo "FLUTTER_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "FLUTTER_APP_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "GITHUB_REPOSITORY_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
+      - name: Import GPG key
+        if: secrets.FLATPAK_GPG_KEY != ''
+        run: |
+          echo "${{ secrets.FLATPAK_GPG_KEY }}" | base64 -d | gpg --batch --import
+      - name: Build Flatpak
+        run: |
+          flatpak-builder --force-clean --repo=repo build-dir linux/packaging/flatpak/com.arran4.FlutterGoogleDatastore.yml
+          flatpak build-bundle repo FlutterGoogleDatastore.flatpak com.arran4.FlutterGoogleDatastore $SEMANTIC_VERSION
+      - name: Push Flatpak to repository
+        env:
+          FLATPAK_REPO_URL: ${{ secrets.FLATPAK_REPO_URL }}
+          FLATPAK_GPG_KEY_ID: ${{ secrets.FLATPAK_GPG_KEY_ID }}
+        run: |
+          flatpak remote-add --if-not-exists release "$FLATPAK_REPO_URL" || true
+          flatpak build-push --gpg-sign="$FLATPAK_GPG_KEY_ID" release repo com.arran4.FlutterGoogleDatastore
+      - name: Upload Flatpak bundle
+        run: |
+          gh release upload "$GITHUB_REF_NAME" FlutterGoogleDatastore.flatpak --clobber
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
   macos:
     runs-on: macos-15
     steps:
@@ -137,6 +182,7 @@ jobs:
     needs:
       - windows
       - linux
+      - flatpak
       - macos
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ edges remain but the application is fully functional.
 Pre-built packages for Linux, macOS, Windows, Android and iOS are available on
 the [GitHub releases](https://github.com/arran4/flutter_google_datastore/releases)
 page.
+Flatpak bundles are automatically published to the configured Flatpak repository when a release tag is pushed.
 
 ## Building
 This project uses [FastForge](https://pub.dev/packages/fastforge) (formerly

--- a/linux/packaging/flatpak/com.arran4.FlutterGoogleDatastore.yml
+++ b/linux/packaging/flatpak/com.arran4.FlutterGoogleDatastore.yml
@@ -1,0 +1,23 @@
+app-id: com.arran4.FlutterGoogleDatastore
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: flutter_google_datastore
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=home
+modules:
+  - name: flutter_google_datastore
+    buildsystem: simple
+    build-commands:
+      - git clone https://github.com/flutter/flutter.git -b stable flutter
+      - flutter/bin/flutter config --enable-linux-desktop
+      - flutter/bin/flutter pub get
+      - flutter/bin/flutter build linux --release
+      - install -Dm755 build/linux/x64/release/bundle/flutter_google_datastore /app/bin/flutter_google_datastore
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
## Summary
- release workflow includes a new job that builds and deploys a Flatpak bundle when a tag is pushed
- add Flatpak manifest for building the app
- mention Flatpak bundles in README

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685013693690832fa6a2687443c09756