### PR TITLE
Handle unawaited navigation in settings

### DIFF
--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_google_datastore/main.dart';
 import 'package:settings_ui/settings_ui.dart';
@@ -39,9 +41,11 @@ class SettingsWidgetState extends State<SettingsWidget> {
                 title: const Text('Delete Database'),
                 description: Text("SQLFile: $fp"),
                 onPressed: (BuildContext context) {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => const DeleteDatabaseScreen(),
+                  unawaited(
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => const DeleteDatabaseScreen(),
+                      ),
                     ),
                   );
                 },


### PR DESCRIPTION
## Summary
- wrap the settings navigation push with `unawaited` to satisfy the unawaited futures lint
- add the required `dart:async` import for the helper

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68db53237c70832f9a81ecd321eca086