### PR TITLE
Make delete flow await database deletion

### DIFF
--- a/lib/database.dart
+++ b/lib/database.dart
@@ -72,7 +72,7 @@ class DB {
     return project;
   }
 
-  void deleteEntireDatabase() async {
+  Future<void> deleteEntireDatabase() async {
     String fn = await filepath();
     Database db = await _db;
     await db.close();

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -76,7 +76,9 @@ class DeleteDatabaseScreen extends StatelessWidget {
                   child: const Text("Don't Delete"),
                 ),
                 ElevatedButton(
-                  onPressed: () => deleteProject(context),
+                  onPressed: () async {
+                    await deleteProject(context);
+                  },
                   style: ButtonStyle(
                     backgroundColor: MaterialStateProperty.resolveWith((states) => Colors.red),
                   ),
@@ -95,8 +97,8 @@ class DeleteDatabaseScreen extends StatelessWidget {
     Navigator.of(context).pop();
   }
 
-  void deleteProject(BuildContext context) async {
-    db.deleteEntireDatabase();
+  Future<void> deleteProject(BuildContext context) async {
+    await db.deleteEntireDatabase();
     if (context.mounted) {
       Navigator.of(context).pop();
     }


### PR DESCRIPTION
## Summary
- make the settings delete action asynchronous and await the database cleanup before closing the dialog
- update the database helper to return a Future so callers can await the deletion

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68db5323f200832f811855635276a2a0