### PR TITLE
Fix async update project handling

### DIFF
--- a/lib/database.dart
+++ b/lib/database.dart
@@ -127,8 +127,8 @@ class DB {
     if (authMode != null) {
       values["authMode"] = authMode;
     }
-    db.update(Project.name, values, where: "id=?", whereArgs: <Object?>[id]);
-    return getProject(id);
+    await db.update(Project.name, values, where: "id=?", whereArgs: <Object?>[id]);
+    return await getProject(id);
   }
 }
 


### PR DESCRIPTION
## Summary
- await the database update when persisting project changes
- return the refreshed project after the awaited update to keep async flow consistent

## Testing
- flutter analyze

------
https://chatgpt.com/codex/tasks/task_e_68db5325ab44832f81a9c7a7c1dca7bb