### PR TITLE
Implement Blob Editing in Property Editor

### DIFF
--- a/lib/entity.dart
+++ b/lib/entity.dart
@@ -971,6 +971,21 @@ class _PropertyAddEditDeleteDialogState extends State<PropertyAddEditDeleteDialo
                   onPressed: _uploadBlob,
                   tooltip: "Upload File",
                 ),
+                IconButton(
+                  icon: const Icon(Icons.edit_note),
+                  onPressed: () async {
+                    List<int>? result = await showDialog<List<int>>(
+                      context: context,
+                      builder: (context) => HexEditorDialog(initialBytes: _blobValue),
+                    );
+                    if (result != null) {
+                      setState(() {
+                        _blobValue = result;
+                      });
+                    }
+                  },
+                  tooltip: "Edit Hex",
+                ),
                 if (_blobValue != null)
                   IconButton(
                     icon: const Icon(Icons.clear),
@@ -1300,6 +1315,92 @@ class _PropertyAddEditDeleteDialogState extends State<PropertyAddEditDeleteDialo
       _microsecondController.text = d!.microsecond.toString();
       _timezoneController.text = d!.timeZoneName;
     }
+  }
+}
+
+class HexEditorDialog extends StatefulWidget {
+  final List<int>? initialBytes;
+
+  const HexEditorDialog({Key? key, this.initialBytes}) : super(key: key);
+
+  @override
+  State<HexEditorDialog> createState() => _HexEditorDialogState();
+}
+
+class _HexEditorDialogState extends State<HexEditorDialog> {
+  late TextEditingController _controller;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    String hexString = "";
+    if (widget.initialBytes != null) {
+      hexString = widget.initialBytes!.map((b) => b.toRadixString(16).padLeft(2, '0')).join(" ");
+    }
+    _controller = TextEditingController(text: hexString);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("Hex Viewer/Editor"),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text("Edit hex values (space separated)"),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _controller,
+            maxLines: 10,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              errorText: _error,
+            ),
+            style: const TextStyle(fontFamily: 'Courier New'),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text("Cancel"),
+        ),
+        TextButton(
+          onPressed: () {
+            try {
+              String text = _controller.text.replaceAll(RegExp(r'\s+'), '');
+              if (text.length % 2 != 0) {
+                setState(() {
+                  _error = "Hex string must have an even length";
+                });
+                return;
+              }
+              List<int> bytes = [];
+              for (int i = 0; i < text.length; i += 2) {
+                String byteString = text.substring(i, i + 2);
+                int? byte = int.tryParse(byteString, radix: 16);
+                if (byte == null) {
+                  setState(() {
+                    _error = "Invalid hex character: $byteString";
+                  });
+                  return;
+                }
+                bytes.add(byte);
+              }
+              Navigator.of(context).pop(bytes);
+            } catch (e) {
+              setState(() {
+                _error = "Error parsing hex: $e";
+              });
+            }
+          },
+          child: const Text("Save"),
+        ),
+      ],
+    );
   }
 }
 

--- a/lib/entity.dart
+++ b/lib/entity.dart
@@ -812,6 +812,25 @@ class _PropertyAddEditDeleteDialogState extends State<PropertyAddEditDeleteDialo
   List<dsv1.PathElement>? _keyPath;
   List<dsv1.Value> _arrayValues = [];
   Map<String, dsv1.Value> newProperties = {};
+  List<int>? _blobValue;
+
+  Future<void> _uploadBlob() async {
+    FilePickerResult? result = await FilePicker.platform.pickFiles();
+    if (result != null) {
+      PlatformFile file = result.files.single;
+      List<int> bytes;
+      if (file.bytes != null) {
+        bytes = file.bytes!;
+      } else if (file.path != null) {
+        bytes = await File(file.path!).readAsBytes();
+      } else {
+        return;
+      }
+      setState(() {
+        _blobValue = bytes;
+      });
+    }
+  }
 
   @override
   void initState() {
@@ -940,7 +959,32 @@ class _PropertyAddEditDeleteDialogState extends State<PropertyAddEditDeleteDialo
           ),
         ];
       case "blob":
-        break; // TODO
+        return [
+          ListTile(
+            title: Text("Blob Content (${_blobValue?.length ?? 0} bytes)"),
+            subtitle: _blobValue == null ? const Text("No data") : const Text("Data present"),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.upload_file),
+                  onPressed: _uploadBlob,
+                  tooltip: "Upload File",
+                ),
+                if (_blobValue != null)
+                  IconButton(
+                    icon: const Icon(Icons.clear),
+                    onPressed: () {
+                      setState(() {
+                        _blobValue = null;
+                      });
+                    },
+                    tooltip: "Clear",
+                  ),
+              ],
+            ),
+          ),
+        ];
       case "array":
         return [
           ..._arrayValues.map((dsv1.Value each) => ValueAddEditRow(
@@ -1127,7 +1171,10 @@ class _PropertyAddEditDeleteDialogState extends State<PropertyAddEditDeleteDialo
         );
         break;
       case "blob":
-        throw UnimplementedError();
+        value = dsv1.Value(
+          blobValue: _blobValue != null ? base64Encode(_blobValue!) : null,
+        );
+        break;
       case "array":
         value = dsv1.Value(
           arrayValue: dsv1.ArrayValue(
@@ -1201,7 +1248,7 @@ class _PropertyAddEditDeleteDialogState extends State<PropertyAddEditDeleteDialo
         _textEditingController = TextEditingController(text: value?.stringValue ?? "");
         break;
       case "blob":
-        // TODO
+        _blobValue = value?.blobValue != null ? base64Decode(value!.blobValue!) : null;
         break;
       case "array":
         _arrayValues = [...(value?.arrayValue?.values ?? [])];


### PR DESCRIPTION
Implemented blob editing functionality in the Property Editor. Users can now upload files to set blob values, which are stored as Base64 encoded strings in the Datastore entity. The UI displays the blob size and provides options to upload a new file or clear the existing value.

---
*PR created automatically by Jules for task [17563716260548445140](https://jules.google.com/task/17563716260548445140) started by @arran4*