### PR TITLE
fix: resolve flutter analyze context.mounted failures

### DIFF
--- a/lib/entity.dart
+++ b/lib/entity.dart
@@ -526,9 +526,7 @@ class _ViewEntityState extends State<ViewEntity> {
     String jsonString = jsonEncode(map);
     File file = File(filePath);
     await file.writeAsString(jsonString);
-    if (!context.mounted) {
-      return;
-    }
+    if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text('JSON data saved to file: $filePath'),
@@ -555,7 +553,7 @@ class _ViewEntityState extends State<ViewEntity> {
         dsv1.Value newValue = dsv1.Value.fromJson(value);
         resultProps[key] = newValue;
       });
-      if (context.mounted) {
+      if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('JSON data read from file: $filePath'),
@@ -566,7 +564,7 @@ class _ViewEntityState extends State<ViewEntity> {
       }
       return resultProps;
     } catch (e) {
-      if (context.mounted) {
+      if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Error loading JSON file: $e'),
@@ -1022,7 +1020,7 @@ class _PropertyAddEditDeleteDialogState
     List<int> bytes = base64Decode(_blobValue!);
     File file = File(filePath);
     await file.writeAsBytes(bytes);
-    if (!context.mounted) {
+    if (!mounted) {
       return;
     }
     ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
Fixed multiple instances in `lib/entity.dart` where `context.mounted` and `!context.mounted` were being used incorrectly across async boundaries inside `State` classes. The variables were replaced with `mounted` and `!mounted` respectively to satisfy the linter's `use_build_context_synchronously` rule. `flutter pub get` was run to address any implicit missing package dependencies affecting other files. Tested to ensure no functional regressions using `flutter test` and confirmed clean checks via `flutter analyze`.

---
*PR created automatically by Jules for task [16611003998919626982](https://jules.google.com/task/16611003998919626982) started by @arran4*