### PR TITLE
fix: update Kotlin version to 2.1.0 to fix android release build

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include(":app")


### PR DESCRIPTION
Updated the Kotlin Android plugin version (`org.jetbrains.kotlin.android`) to `2.1.0` in `android/settings.gradle.kts` to fix a compilation issue during Android release builds where `google_sign_in_android` requires a newer version of Kotlin than the previously set `1.8.22`.

---
*PR created automatically by Jules for task [14209786931128437598](https://jules.google.com/task/14209786931128437598) started by @arran4*