### PR TITLE
Add CI workflow to smoke-test FastForge Flatpak packaging

### DIFF
--- a/.github/workflows/test-fastforge-flatpak.yml
+++ b/.github/workflows/test-fastforge-flatpak.yml
@@ -15,6 +15,11 @@ on:
         description: 'Signing key for Flatpak'
         required: false
         default: ''
+      upload_artifacts:
+        description: 'Upload generated flatpak and manifest to artifacts for 1 day'
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   flatpak:
@@ -84,11 +89,14 @@ jobs:
             \( -name '*.flatpak' -o -name 'manifest.yml' \) \
             -print
 
-      - name: Upload Flatpak
-        if: success()
+      - name: Upload Flatpak and Manifest
+        if: success() && inputs.upload_artifacts == true
         uses: actions/upload-artifact@v4
         with:
           name: flutter-google-datastore-flatpak
+          retention-days: 1
           path: |
             **/*.flatpak
+            **/manifest.yml
+            **/manifest.json
           if-no-files-found: error

--- a/.github/workflows/test-fastforge-flatpak.yml
+++ b/.github/workflows/test-fastforge-flatpak.yml
@@ -1,0 +1,94 @@
+name: Test FastForge Flatpak PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      fastforge_ref:
+        description: 'FastForge PR branch or ref'
+        required: true
+        default: 'flatpak-packaging-16578285889526019589'
+      flatpak_endpoint:
+        description: 'Flatpak remote endpoint URL'
+        required: true
+        default: 'https://flathub.org/repo/flathub.flatpakrepo'
+      signing_key:
+        description: 'Signing key for Flatpak'
+        required: false
+        default: ''
+
+jobs:
+  flatpak:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout application
+        uses: actions/checkout@v4
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.44.4'
+          cache: true
+
+      - name: Install Flatpak tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+
+      - name: Add Flathub
+        run: |
+          flatpak remote-add --user --if-not-exists \
+            flathub \
+            ${{ github.event.inputs.flatpak_endpoint }}
+
+      - name: Install Flatpak runtime and SDK
+        run: |
+          flatpak install --user -y flathub \
+            org.freedesktop.Platform//23.08 \
+            org.freedesktop.Sdk//23.08
+
+      - name: Install application dependencies
+        run: flutter pub get
+
+      - name: Checkout FastForge PR
+        uses: actions/checkout@v4
+        with:
+          repository: arran4/fastforge
+          ref: ${{ github.event.inputs.fastforge_ref }}
+          path: _fastforge
+
+      - name: Activate FastForge from PR
+        run: |
+          dart pub global activate \
+            --source path \
+            "$GITHUB_WORKSPACE/_fastforge/packages/fastforge"
+
+          echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
+
+      - name: Show FastForge version
+        run: fastforge --version || true
+
+      - name: Build Flatpak
+        env:
+          SIGNING_KEY: ${{ github.event.inputs.signing_key }}
+        run: |
+          fastforge package \
+            --platform linux \
+            --targets flatpak
+
+      - name: Show generated files
+        if: always()
+        run: |
+          find . \
+            -type f \
+            \( -name '*.flatpak' -o -name 'manifest.yml' \) \
+            -print
+
+      - name: Upload Flatpak
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flutter-google-datastore-flatpak
+          path: |
+            **/*.flatpak
+          if-no-files-found: error

--- a/linux/packaging/flatpak/make_config.yaml
+++ b/linux/packaging/flatpak/make_config.yaml
@@ -1,0 +1,7 @@
+app_id: com.arran4.flutter_google_datastore
+runtime: org.freedesktop.Platform
+runtime_version: '23.08'
+sdk: org.freedesktop.Sdk
+finish_args:
+  - --share=network
+  - --filesystem=home


### PR DESCRIPTION
This commit introduces a new workflow and Flatpak configuration file to use this repository as a smoke-test application for a FastForge PR.

- Creates `linux/packaging/flatpak/make_config.yaml`.
- Creates `.github/workflows/test-fastforge-flatpak.yml`.
- Configured manual workflow dispatch with inputs for `fastforge_ref`, `flatpak_endpoint`, and `signing_key` for flexibility in testing.

---
*PR created automatically by Jules for task [14308201707936269843](https://jules.google.com/task/14308201707936269843) started by @arran4*